### PR TITLE
Implement analysis engine and GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8
+      - name: Lint
+        run: flake8 .
+      - name: Test
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Marker Engine
+![CI](https://github.com/USER/REPO/actions/workflows/ci.yml/badge.svg)
 
 A modular platform for chat analysis built with FastAPI and Streamlit. It processes chat exports and audio files, chunks text, and applies YAML-based rules to generate insights.
 

--- a/demo_chat.txt
+++ b/demo_chat.txt
@@ -1,0 +1,19 @@
+15.03.24, 14:30 - Max Mustermann: Hey Leute! Wie geht's euch?
+15.03.24, 14:31 - Anna Schmidt: Hi Max! Mir geht's super, danke! Und dir?
+15.03.24, 14:32 - Max Mustermann: Auch gut! Habt ihr schon die Neuigkeiten gehört?
+15.03.24, 14:33 - Tom Weber: Nein, was denn?
+15.03.24, 14:34 - Max Mustermann: Wir haben das Projekt gewonnen! 🎉
+15.03.24, 14:35 - Anna Schmidt: Das ist ja fantastisch! Herzlichen Glückwunsch! 🥳
+15.03.24, 14:36 - Tom Weber: Wow, super News! Das haben wir uns verdient!
+15.03.24, 14:37 - Max Mustermann: Ja, die ganze harte Arbeit hat sich gelohnt.
+15.03.24, 14:38 - Anna Schmidt: Wann fangen wir denn an?
+15.03.24, 14:39 - Max Mustermann: Nächste Woche Montag geht's los. Ich schicke euch noch die Details.
+15.03.24, 14:40 - Tom Weber: Perfekt! Ich freu mich schon drauf.
+15.03.24, 14:41 - Anna Schmidt: Ich auch! Das wird bestimmt spannend.
+15.03.24, 14:42 - Max Mustermann: Auf jeden Fall! Lasst uns morgen nochmal zusammensetzen und alles besprechen.
+15.03.24, 14:43 - Tom Weber: Gute Idee. Um welche Uhrzeit?
+15.03.24, 14:44 - Max Mustermann: Wie wäre es mit 10 Uhr?
+15.03.24, 14:45 - Anna Schmidt: Passt mir gut!
+15.03.24, 14:46 - Tom Weber: Mir auch. Dann bis morgen!
+15.03.24, 14:47 - Max Mustermann: Super, bis morgen dann! 👋
+15.03.24, 14:48 - Anna Schmidt: Bis morgen! Schönen Abend noch! 😊 

--- a/mewt/__init__.py
+++ b/mewt/__init__.py
@@ -1,0 +1,11 @@
+"""MEWT analysis package."""
+
+from .schema_loader import SchemaLoader
+from .marker_frequency import MarkerFrequencyCounter
+from .drift_axis import DriftAxisAnalyzer
+
+__all__ = [
+    "SchemaLoader",
+    "MarkerFrequencyCounter",
+    "DriftAxisAnalyzer",
+]

--- a/mewt/drift_axis.py
+++ b/mewt/drift_axis.py
@@ -1,0 +1,31 @@
+from typing import Iterable, Set, Protocol
+
+
+class _ChunkLike(Protocol):
+    matches: Iterable
+
+class DriftAxisAnalyzer:
+    """Simple drift analyzer comparing positive and negative marker usage."""
+
+    def __init__(self, positive_markers: Set[str] | None = None, negative_markers: Set[str] | None = None):
+        self.positive_markers = positive_markers or set()
+        self.negative_markers = negative_markers or set()
+
+    def analyze(self, chunks: Iterable[_ChunkLike]) -> float:
+        """Return difference between second half and first half marker scores."""
+        chunks = list(chunks)
+        if not chunks:
+            return 0.0
+        mid = len(chunks) // 2
+        def score(sub):
+            total = 0
+            for chunk in sub:
+                for m in chunk.matches:
+                    if m.marker_id in self.positive_markers:
+                        total += m.score
+                    if m.marker_id in self.negative_markers:
+                        total -= m.score
+            return total
+        first = score(chunks[:mid or 1])
+        second = score(chunks[mid:])
+        return float(second - first)

--- a/mewt/engine.py
+++ b/mewt/engine.py
@@ -1,0 +1,45 @@
+import argparse
+import json
+from pathlib import Path
+from .schema_loader import SchemaLoader
+from .marker_frequency import MarkerFrequencyCounter
+from .drift_axis import DriftAxisAnalyzer
+from monorepo.backend.app.services.chunking_service import ChunkingService
+from monorepo.backend.app.services.analysis_service import AnalysisService
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Run chat analysis")
+    parser.add_argument("text_file", help="Path to chat text file")
+    parser.add_argument("--schema", help="Schema file", required=False)
+    args = parser.parse_args(argv)
+
+    text_path = Path(args.text_file)
+    text = text_path.read_text(encoding="utf-8")
+
+    schema = {}
+    if args.schema:
+        schema = SchemaLoader().load(args.schema)
+
+    marker_dir = Path(schema.get("marker_dir", "monorepo/marker_bank"))
+    service = AnalysisService(marker_dir=marker_dir)
+    chunker = ChunkingService()
+
+    chunks = chunker.chunk_text(text)
+    markers = service.load_markers()
+    results = [service.analyze_chunk(c, markers) for c in chunks]
+
+    counter = MarkerFrequencyCounter()
+    freq = counter.count(results)
+
+    drift = DriftAxisAnalyzer(
+        set(schema.get("positive_markers", [])),
+        set(schema.get("negative_markers", [])),
+    ).analyze(results)
+
+    output = {"frequencies": freq, "drift": drift, "chunks": [r.model_dump() for r in results]}
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/mewt/marker_frequency.py
+++ b/mewt/marker_frequency.py
@@ -1,0 +1,16 @@
+from collections import Counter
+from typing import Iterable, Protocol
+
+
+class _ChunkLike(Protocol):
+    matches: Iterable
+
+class MarkerFrequencyCounter:
+    """Count occurrences of markers across chunks."""
+
+    def count(self, chunks: Iterable[_ChunkLike]) -> dict[str, int]:
+        freq: Counter[str] = Counter()
+        for chunk in chunks:
+            for match in chunk.matches:
+                freq[match.marker_id] += 1
+        return dict(freq)

--- a/mewt/schema_loader.py
+++ b/mewt/schema_loader.py
@@ -1,0 +1,17 @@
+import json
+import yaml
+from pathlib import Path
+
+class SchemaLoader:
+    """Load analysis schemas in JSON or YAML format."""
+
+    def load(self, path: str | Path) -> dict:
+        file_path = Path(path)
+        if not file_path.exists():
+            raise FileNotFoundError(path)
+        if file_path.suffix in {'.yml', '.yaml'}:
+            return yaml.safe_load(file_path.read_text())
+        elif file_path.suffix == '.json':
+            return json.loads(file_path.read_text())
+        else:
+            raise ValueError(f"Unsupported schema format: {file_path.suffix}")

--- a/monorepo/backend/app/api/v1/endpoints/analysis.py
+++ b/monorepo/backend/app/api/v1/endpoints/analysis.py
@@ -2,6 +2,7 @@ import uuid
 import zipfile
 from fastapi import APIRouter, UploadFile, File
 from fastapi.responses import JSONResponse
+from mewt.marker_frequency import MarkerFrequencyCounter
 from ..models import AnalysisResult
 from ....services.transcription_service import TranscriptionService
 from ....services.chunking_service import ChunkingService
@@ -52,3 +53,18 @@ async def get_result(analysis_id: str):
     if not data:
         return JSONResponse(status_code=404, content={"detail": "not found"})
     return data
+
+
+@router.get("/summary/{analysis_id}")
+async def get_summary(analysis_id: str):
+    data = _results.get(analysis_id)
+    if not data:
+        return JSONResponse(status_code=404, content={"detail": "not found"})
+    freq = MarkerFrequencyCounter().count(data.chunks)
+    return {"id": analysis_id, "frequencies": freq}
+
+
+@router.post("/reload")
+async def reload_results():
+    _results.clear()
+    return {"status": "reloaded"}

--- a/relationship.json
+++ b/relationship.json
@@ -1,0 +1,5 @@
+{
+  "marker_dir": "monorepo/marker_bank",
+  "positive_markers": ["greet", "emotion_happy"],
+  "negative_markers": ["scam"]
+}

--- a/tests/test_analysis_modules.py
+++ b/tests/test_analysis_modules.py
@@ -1,0 +1,20 @@
+from mewt.marker_frequency import MarkerFrequencyCounter
+from mewt.drift_axis import DriftAxisAnalyzer
+from monorepo.backend.app.api.v1.models import ChunkResult, MarkerMatch
+
+
+def make_chunk(ids):
+    return ChunkResult(text="", matches=[MarkerMatch(marker_id=i, score=1) for i in ids])
+
+
+def test_marker_frequency_counter():
+    chunks = [make_chunk(["a", "b"]), make_chunk(["a"])]
+    freq = MarkerFrequencyCounter().count(chunks)
+    assert freq == {"a": 2, "b": 1}
+
+
+def test_drift_axis_analyzer():
+    chunks = [make_chunk(["pos"]), make_chunk(["neg", "neg"]), make_chunk(["pos"])]
+    analyzer = DriftAxisAnalyzer({"pos"}, {"neg"})
+    result = analyzer.analyze(chunks)
+    assert result == -2.0


### PR DESCRIPTION
## Summary
- add `mewt` package with engine, schema loader and analyzers
- expose new `/summary` and `/reload` routes
- integrate GitHub Actions workflow and badge
- provide demo chat and schema files
- test MarkerFrequencyCounter and DriftAxisAnalyzer

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882680662948322a517bd27ad64c4cb